### PR TITLE
Add option for "External Pull To Clear."

### DIFF
--- a/preferences/Resources/PriorityHub.plist
+++ b/preferences/Resources/PriorityHub.plist
@@ -119,6 +119,14 @@ items = (
     cell = PSSwitchCell;
     default = 0;
     defaults = "com.thomasfinch.priorityhub";
+    key = externalPullToClear;
+    PostNotification = com.thomasfinch.priorityhub-prefschanged;
+    label = "External Pull To Clear";
+  },
+  {
+    cell = PSSwitchCell;
+    default = 0;
+    defaults = "com.thomasfinch.priorityhub";
     key = privacyMode;
     PostNotification = com.thomasfinch.priorityhub-prefschanged;
     label = "Privacy Mode";


### PR DESCRIPTION
This allows Priority Hub to post a notification that third party tweaks can monitor so they can perform their own Pull to Clear methods.

I am using this in the new alpha version of my tweak Perpetual 8, that I am currently working on. The original version, Perpetual, worked with Priority Hub's default Pull to Clear method but, because of some back end changes I made in Perpetual 8, it no longer works.